### PR TITLE
Make mockups for rendering books

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,1 @@
+NEXT_PUBLIC_MSW=true

--- a/.gitignore
+++ b/.gitignore
@@ -32,7 +32,8 @@ yarn-error.log*
 .pnpm-debug.log*
 
 # env files (can opt-in for committing if needed)
-.env*
+.env.local
+.env.production
 
 # vercel
 .vercel

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -45,7 +45,7 @@ const eslintConfig = defineConfig([
 
   prettierConfig,
 
-  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts']),
+  globalIgnores(['.next/**', 'out/**', 'build/**', 'next-env.d.ts', 'public/mockServiceWorker.js']),
 ])
 
 export default eslintConfig

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -25,6 +25,7 @@ const eslintConfig = defineConfig([
       'fsd-lint/no-cross-slice-dependency': 'error',
       'fsd-lint/no-global-store-imports': 'error',
       'fsd-lint/no-ui-in-business-logic': 'error',
+      'fsd-lint/ordered-imports': 'warn',
     },
   },
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,16 +10,6 @@ const nextConfig: NextConfig = {
       },
     },
   },
-  // Временная ссылка на фотостоки, в будущем нужно удалить
-  images: {
-    remotePatterns: [
-      {
-        protocol: 'https',
-        hostname: 'picsum.photos',
-        pathname: '/**',
-      },
-    ],
-  },
 }
 
 const withNextIntl = createNextIntlPlugin('./src/shared/lib/i18n/request.ts')

--- a/next.config.ts
+++ b/next.config.ts
@@ -10,6 +10,16 @@ const nextConfig: NextConfig = {
       },
     },
   },
+  // Временная ссылка на фотостоки, в будущем нужно удалить
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'picsum.photos',
+        pathname: '/**',
+      },
+    ],
+  },
 }
 
 const withNextIntl = createNextIntlPlugin('./src/shared/lib/i18n/request.ts')

--- a/package.json
+++ b/package.json
@@ -31,7 +31,14 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-fsd-lint": "^1.0.10",
     "eslint-plugin-prettier": "^5.5.5",
+    "msw": "^2.12.10",
     "prettier": "^3.8.0",
     "typescript": "^5"
+  },
+  "msw": {
+    "workerDirectory": [
+      "./public",
+      "public"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -66,6 +66,9 @@ importers:
       eslint-plugin-prettier:
         specifier: ^5.5.5
         version: 5.5.5(eslint-config-prettier@10.1.8(eslint@9.39.2(jiti@2.6.1)))(eslint@9.39.2(jiti@2.6.1))(prettier@3.8.0)
+      msw:
+        specifier: ^2.12.10
+        version: 2.12.10(@types/node@20.19.30)(typescript@5.9.3)
       prettier:
         specifier: ^3.8.0
         version: 3.8.0
@@ -885,6 +888,41 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@inquirer/ansi@1.0.2':
+    resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
+    engines: {node: '>=18'}
+
+  '@inquirer/confirm@5.1.21':
+    resolution: {integrity: sha512-KR8edRkIsUayMXV+o3Gv+q4jlhENF9nMYUZs9PA2HzrXeHI8M5uDag70U7RJn9yyiMZSbtF5/UexBtAVtZGSbQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/core@10.3.2':
+    resolution: {integrity: sha512-43RTuEbfP8MbKzedNqBrlhhNKVwoK//vUFNW3Q3vZ88BLcrs4kYpGg+B2mm5p2K/HfygoCxuKwJJiv8PbGmE0A==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
+  '@inquirer/figures@1.0.15':
+    resolution: {integrity: sha512-t2IEY+unGHOzAaVM5Xx6DEWKeXlDDcNPeDyUpsRc6CUhBfU3VQOEl+Vssh7VNp1dR8MdUJBWhuObjXCsVpjN5g==}
+    engines: {node: '>=18'}
+
+  '@inquirer/type@3.0.10':
+    resolution: {integrity: sha512-BvziSRxfz5Ov8ch0z/n3oijRSEcEsHnhggm4xFZe93DHcUCTlutlq9Ox4SVENAfcRD22UQq7T/atg9Wr3k09eA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@types/node': '>=18'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -900,6 +938,10 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@mswjs/interceptors@0.41.2':
+    resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
+    engines: {node: '>=18'}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -977,6 +1019,15 @@ packages:
   '@nolyfill/is-core-module@1.0.39':
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
+
+  '@open-draft/deferred-promise@2.2.0':
+    resolution: {integrity: sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==}
+
+  '@open-draft/logger@0.3.0':
+    resolution: {integrity: sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==}
+
+  '@open-draft/until@2.1.0':
+    resolution: {integrity: sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==}
 
   '@parcel/watcher-android-arm64@2.5.6':
     resolution: {integrity: sha512-YQxSS34tPF/6ZG7r/Ih9xy+kP/WwediEUsqmtf0cuCV5TPPKw/PQHRhueUo6JdeFJaqV3pyjm0GdYjZotbRt/A==}
@@ -1280,6 +1331,9 @@ packages:
   '@types/react@19.2.8':
     resolution: {integrity: sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==}
 
+  '@types/statuses@2.0.6':
+    resolution: {integrity: sha512-xMAgYwceFhRA2zY+XbEA7mxYbA093wdiW8Vu6gZPGWy9cmOyU9XesH1tNcEWsKFd5Vzrqx5T3D38PWx1FIIXkA==}
+
   '@types/use-sync-external-store@0.0.6':
     resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
@@ -1458,6 +1512,10 @@ packages:
   ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
@@ -1597,8 +1655,16 @@ packages:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
 
+  cli-width@4.1.0:
+    resolution: {integrity: sha512-ouuZd4/dm2Sw5Gmqy6bGyNNNe1qt9RpmxveLSO7KcgsTnU7RXfsw+/bukWGo1abgBiMAic068rclZsO4IWmmxQ==}
+    engines: {node: '>= 12'}
+
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1624,6 +1690,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.48.0:
     resolution: {integrity: sha512-OM4cAF3D6VtH/WkLtWvyNC56EZVXsZdU3iqaMG2B4WvYrlqU831pc4UtG5yp0sE9z8Y02wVN7PjW5Zf9Gt0f1Q==}
@@ -1747,6 +1817,9 @@ packages:
 
   electron-to-chromium@1.5.267:
     resolution: {integrity: sha512-0Drusm6MVRXSOJpGbaSVgcQsuB4hEkMpHXaVstcPmhu5LIedxs1xNK/nIxmQIU/RPC0+1/o0AVZfBTkTNJOdUw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
@@ -2021,6 +2094,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -2060,6 +2137,10 @@ packages:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
 
+  graphql@16.12.0:
+    resolution: {integrity: sha512-DKKrynuQRne0PNpEbzuEdHlYOMksHSUI8Zc9Unei5gTsMNA2/vMpoMz/yKba50pejK56qj98qM0SjYxAKi13gQ==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+
   has-bigints@1.1.0:
     resolution: {integrity: sha512-R3pbpkcIqv2Pm3dUwgjclDRVmWpTJW2DcMzcIhEXEx1oh/CEMObMm3KLmRJOdvhM7o4uQBnwr8pzRK2sJWIqfg==}
     engines: {node: '>= 0.4'}
@@ -2086,6 +2167,9 @@ packages:
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  headers-polyfill@4.0.3:
+    resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
   hermes-estree@0.25.1:
     resolution: {integrity: sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw==}
@@ -2171,6 +2255,10 @@ packages:
     resolution: {integrity: sha512-1pC6N8qWJbWoPtEjgcL2xyhQOP491EQjeUo3qTKcmV8YSDDJrOepfG8pcC7h/QgnQHYSv0mJ3Z/ZWxmatVrysg==}
     engines: {node: '>= 0.4'}
 
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
   is-generator-function@1.1.2:
     resolution: {integrity: sha512-upqt1SkGkODW9tsGNG5mtXTXtECizwtS2kA161M+gJPc1xdb/Ax629af6YrTwcOeQHbewrPNlE5Dx7kzvXTizA==}
     engines: {node: '>= 0.4'}
@@ -2186,6 +2274,9 @@ packages:
   is-negative-zero@2.0.3:
     resolution: {integrity: sha512-5KoIu2Ngpyek75jXodFvnafB6DJgr3u8uuK0LEZJjrU19DrMD3EVERaR8sjz8CCGgpZvxPl9SuE1GMVPFHx1mw==}
     engines: {node: '>= 0.4'}
+
+  is-node-process@1.2.0:
+    resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
 
   is-number-object@1.1.1:
     resolution: {integrity: sha512-lZhclumE1G6VYD8VHe35wFaIif+CTy5SJIi5+3y4psDgWu4wPDoBhF8NxUOinEc7pHgiTsT6MaBb92rKhhD+Xw==}
@@ -2358,6 +2449,20 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
+  msw@2.12.10:
+    resolution: {integrity: sha512-G3VUymSE0/iegFnuipujpwyTM2GuZAKXNeerUSrG2+Eg391wW63xFs5ixWsK9MWzr1AGoSkYGmyAzNgbR3+urw==}
+    engines: {node: '>=18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>= 4.8.x'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  mute-stream@2.0.0:
+    resolution: {integrity: sha512-WWdIxpyjEn+FhQJQQv9aQAYlHoNVdzIzUySNV1gHUPDSdZJ3yZn7pAAbQcV7B56Mvu881q9FZV+0Vx2xC44VWA==}
+    engines: {node: ^18.17.0 || >=20.5.0}
+
   nanoid@3.3.11:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
@@ -2460,6 +2565,9 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  outvariant@1.4.3:
+    resolution: {integrity: sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==}
+
   own-keys@1.0.1:
     resolution: {integrity: sha512-qFOyK5PjiWZd+QQIh+1jhdb9LpxTF0qs7Pm8o5QHYZ0M3vKqSqzsZaEB6oWlxZ+q2sJBMI/Ktgd2N5ZwQoRHfg==}
     engines: {node: '>= 0.4'}
@@ -2490,6 +2598,9 @@ packages:
 
   path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-to-regexp@6.3.0:
+    resolution: {integrity: sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -2605,6 +2716,10 @@ packages:
     resolution: {integrity: sha512-NZQZdC5wOE/H3UT28fVGL+ikOZcEzfMGk/c3iN9UGxzWHMa1op7274oyiUVrAG4B2EuFhus8SvkaYnhvW92p9Q==}
     hasBin: true
 
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
   reselect@5.1.1:
     resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
@@ -2623,6 +2738,9 @@ packages:
   resolve@2.0.0-next.5:
     resolution: {integrity: sha512-U7WjGVG9sH8tvjW5SmGbQuui75FiyjAX72HX15DwBBwF9dNiQZRQAg9nnPhYy+TUnE0+VcrttuvNI8oSxZcocA==}
     hasBin: true
+
+  rettime@0.10.1:
+    resolution: {integrity: sha512-uyDrIlUEH37cinabq0AX4QbgV4HbFZ/gqoiunWQ1UqBtRvTTytwhNYjE++pO/MjPTZL5KQCf2bEoJ/BJNVQ5Kw==}
 
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
@@ -2700,6 +2818,10 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  signal-exit@4.1.0:
+    resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
+    engines: {node: '>=14'}
+
   snake-case@3.0.4:
     resolution: {integrity: sha512-LAOh4z89bGQvl9pFfNF8V146i7o7/CqFPbqzYgP+yYzDIDeS9HaNFtXABamRW+AQzEVODcvE79ljJ+8a9YSdMg==}
 
@@ -2710,9 +2832,20 @@ packages:
   stable-hash@0.0.5:
     resolution: {integrity: sha512-+L3ccpzibovGXFK+Ap/f8LOS0ahMrHTf3xu7mMLSpEGU0EO9ucaysSylKo9eRDFNhWve/y275iPmIZ4z39a9iA==}
 
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
   stop-iteration-iterator@1.1.0:
     resolution: {integrity: sha512-eLoXW/DHyl62zxY4SCaIgnRhuMr6ri4juEYARS8E6sCEqzKpOiE521Ucofdx+KnDZl5xmvGYaaKCk5FEOxJCoQ==}
     engines: {node: '>= 0.4'}
+
+  strict-event-emitter@0.5.1:
+    resolution: {integrity: sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
 
   string.prototype.includes@2.0.1:
     resolution: {integrity: sha512-o7+c9bW6zpAdJHTtujeePODAhkuicdAryFsfVKwA+wGw89wJ4GTY484WTucM9hLtDEOpOvI+aHnzqnC5lHp4Rg==}
@@ -2736,6 +2869,10 @@ packages:
   string.prototype.trimstart@1.0.8:
     resolution: {integrity: sha512-UXSH262CSZY1tfu3G3Secr6uGLCFVPMhIqHjlgCUtCCcgihYc/xKs9djMTMUOb2j1mVSeU8EU6NWc/iQKU6Gfg==}
     engines: {node: '>= 0.4'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
 
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
@@ -2778,13 +2915,28 @@ packages:
     resolution: {integrity: sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
 
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
+  tldts-core@7.0.23:
+    resolution: {integrity: sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==}
+
+  tldts@7.0.23:
+    resolution: {integrity: sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
+
+  tough-cookie@6.0.0:
+    resolution: {integrity: sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==}
+    engines: {node: '>=16'}
 
   ts-api-utils@2.4.0:
     resolution: {integrity: sha512-3TaVTaAv2gTiMB35i3FiGJaRfwb3Pyn/j3m/bfAvGe8FB7CF6u+LMYqYlDh7reQf7UNvoTvdfAqHGmPGOSsPmA==}
@@ -2801,6 +2953,10 @@ packages:
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
+
+  type-fest@5.4.4:
+    resolution: {integrity: sha512-JnTrzGu+zPV3aXIUhnyWJj4z/wigMsdYajGLIYakqyOW1nPllzXEJee0QQbHj+CTIQtXGlAjuK0UY+2xTyjVAw==}
+    engines: {node: '>=20'}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -2856,6 +3012,9 @@ packages:
   unrs-resolver@1.11.1:
     resolution: {integrity: sha512-bSjt9pjaEBnNiGgc9rUiHGKv5l4/TGzDmYw3RhnkJGtLhbnnA/5qJj7x3dNDCRx/PJxu774LlH8lCOlB4hEfKg==}
 
+  until-async@3.0.2:
+    resolution: {integrity: sha512-IiSk4HlzAMqTUseHHe3VhIGyuFmN90zMTpD3Z3y8jeQbzLIq500MVM7Jq2vUAnTKAFPJrqwkzr6PoTcPhGcOiw==}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -2900,12 +3059,36 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  wrap-ansi@7.0.0:
+    resolution: {integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==}
+    engines: {node: '>=10'}
+
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  yoctocolors-cjs@2.1.3:
+    resolution: {integrity: sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw==}
+    engines: {node: '>=18'}
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -3886,6 +4069,34 @@ snapshots:
   '@img/sharp-win32-x64@0.34.5':
     optional: true
 
+  '@inquirer/ansi@1.0.2': {}
+
+  '@inquirer/confirm@5.1.21(@types/node@20.19.30)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@20.19.30)
+      '@inquirer/type': 3.0.10(@types/node@20.19.30)
+    optionalDependencies:
+      '@types/node': 20.19.30
+
+  '@inquirer/core@10.3.2(@types/node@20.19.30)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@20.19.30)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 20.19.30
+
+  '@inquirer/figures@1.0.15': {}
+
+  '@inquirer/type@3.0.10(@types/node@20.19.30)':
+    optionalDependencies:
+      '@types/node': 20.19.30
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -3904,6 +4115,15 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@mswjs/interceptors@0.41.2':
+    dependencies:
+      '@open-draft/deferred-promise': 2.2.0
+      '@open-draft/logger': 0.3.0
+      '@open-draft/until': 2.1.0
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      strict-event-emitter: 0.5.1
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
@@ -3955,6 +4175,15 @@ snapshots:
       fastq: 1.20.1
 
   '@nolyfill/is-core-module@1.0.39': {}
+
+  '@open-draft/deferred-promise@2.2.0': {}
+
+  '@open-draft/logger@0.3.0':
+    dependencies:
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+
+  '@open-draft/until@2.1.0': {}
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -4212,6 +4441,8 @@ snapshots:
     dependencies:
       csstype: 3.2.3
 
+  '@types/statuses@2.0.6': {}
+
   '@types/use-sync-external-store@0.0.6': {}
 
   '@typescript-eslint/eslint-plugin@8.53.0(@typescript-eslint/parser@8.53.0(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3))(eslint@9.39.2(jiti@2.6.1))(typescript@5.9.3)':
@@ -4376,6 +4607,8 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ansi-regex@5.0.1: {}
 
   ansi-styles@4.3.0:
     dependencies:
@@ -4557,7 +4790,15 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
+  cli-width@4.1.0: {}
+
   client-only@0.0.1: {}
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -4576,6 +4817,8 @@ snapshots:
   concat-map@0.0.1: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.1.1: {}
 
   core-js-compat@3.48.0:
     dependencies:
@@ -4706,6 +4949,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.267: {}
+
+  emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
 
@@ -5115,6 +5360,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -5162,6 +5409,8 @@ snapshots:
 
   gopd@1.2.0: {}
 
+  graphql@16.12.0: {}
+
   has-bigints@1.1.0: {}
 
   has-flag@4.0.0: {}
@@ -5183,6 +5432,8 @@ snapshots:
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  headers-polyfill@4.0.3: {}
 
   hermes-estree@0.25.1: {}
 
@@ -5274,6 +5525,8 @@ snapshots:
     dependencies:
       call-bound: 1.0.4
 
+  is-fullwidth-code-point@3.0.0: {}
+
   is-generator-function@1.1.2:
     dependencies:
       call-bound: 1.0.4
@@ -5289,6 +5542,8 @@ snapshots:
   is-map@2.0.3: {}
 
   is-negative-zero@2.0.3: {}
+
+  is-node-process@1.2.0: {}
 
   is-number-object@1.1.1:
     dependencies:
@@ -5449,6 +5704,33 @@ snapshots:
 
   ms@2.1.3: {}
 
+  msw@2.12.10(@types/node@20.19.30)(typescript@5.9.3):
+    dependencies:
+      '@inquirer/confirm': 5.1.21(@types/node@20.19.30)
+      '@mswjs/interceptors': 0.41.2
+      '@open-draft/deferred-promise': 2.2.0
+      '@types/statuses': 2.0.6
+      cookie: 1.1.1
+      graphql: 16.12.0
+      headers-polyfill: 4.0.3
+      is-node-process: 1.2.0
+      outvariant: 1.4.3
+      path-to-regexp: 6.3.0
+      picocolors: 1.1.1
+      rettime: 0.10.1
+      statuses: 2.0.2
+      strict-event-emitter: 0.5.1
+      tough-cookie: 6.0.0
+      type-fest: 5.4.4
+      until-async: 3.0.2
+      yargs: 17.7.2
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - '@types/node'
+
+  mute-stream@2.0.0: {}
+
   nanoid@3.3.11: {}
 
   napi-postinstall@0.3.4: {}
@@ -5567,6 +5849,8 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  outvariant@1.4.3: {}
+
   own-keys@1.0.1:
     dependencies:
       get-intrinsic: 1.3.0
@@ -5597,6 +5881,8 @@ snapshots:
   path-key@3.1.1: {}
 
   path-parse@1.0.7: {}
+
+  path-to-regexp@6.3.0: {}
 
   path-type@4.0.0: {}
 
@@ -5703,6 +5989,8 @@ snapshots:
     dependencies:
       jsesc: 3.1.0
 
+  require-directory@2.1.1: {}
+
   reselect@5.1.1: {}
 
   resolve-from@4.0.0: {}
@@ -5720,6 +6008,8 @@ snapshots:
       is-core-module: 2.16.1
       path-parse: 1.0.7
       supports-preserve-symlinks-flag: 1.0.0
+
+  rettime@0.10.1: {}
 
   reusify@1.1.0: {}
 
@@ -5848,6 +6138,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  signal-exit@4.1.0: {}
+
   snake-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
@@ -5857,10 +6149,20 @@ snapshots:
 
   stable-hash@0.0.5: {}
 
+  statuses@2.0.2: {}
+
   stop-iteration-iterator@1.1.0:
     dependencies:
       es-errors: 1.3.0
       internal-slot: 1.1.0
+
+  strict-event-emitter@0.5.1: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
 
   string.prototype.includes@2.0.1:
     dependencies:
@@ -5912,6 +6214,10 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
   strip-bom@3.0.0: {}
 
   strip-json-comments@3.1.1: {}
@@ -5945,14 +6251,26 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tagged-tag@1.0.0: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
+  tldts-core@7.0.23: {}
+
+  tldts@7.0.23:
+    dependencies:
+      tldts-core: 7.0.23
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
+
+  tough-cookie@6.0.0:
+    dependencies:
+      tldts: 7.0.23
 
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
@@ -5970,6 +6288,10 @@ snapshots:
   type-check@0.4.0:
     dependencies:
       prelude-ls: 1.2.1
+
+  type-fest@5.4.4:
+    dependencies:
+      tagged-tag: 1.0.0
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -6061,6 +6383,8 @@ snapshots:
       '@unrs/resolver-binding-win32-ia32-msvc': 1.11.1
       '@unrs/resolver-binding-win32-x64-msvc': 1.11.1
 
+  until-async@3.0.2: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -6130,9 +6454,37 @@ snapshots:
 
   word-wrap@1.2.5: {}
 
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  wrap-ansi@7.0.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
+
   yocto-queue@0.1.0: {}
+
+  yoctocolors-cjs@2.1.3: {}
 
   zod-validation-error@4.0.2(zod@4.3.5):
     dependencies:

--- a/public/mockServiceWorker.js
+++ b/public/mockServiceWorker.js
@@ -1,0 +1,349 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker.
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ */
+
+const PACKAGE_VERSION = '2.12.10'
+const INTEGRITY_CHECKSUM = '4db4a41e972cec1b64cc569c66952d82'
+const IS_MOCKED_RESPONSE = Symbol('isMockedResponse')
+const activeClientIds = new Set()
+
+addEventListener('install', function () {
+  self.skipWaiting()
+})
+
+addEventListener('activate', function (event) {
+  event.waitUntil(self.clients.claim())
+})
+
+addEventListener('message', async function (event) {
+  const clientId = Reflect.get(event.source || {}, 'id')
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: {
+          packageVersion: PACKAGE_VERSION,
+          checksum: INTEGRITY_CHECKSUM,
+        },
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: {
+          client: {
+            id: client.id,
+            frameType: client.frameType,
+          },
+        },
+      })
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+addEventListener('fetch', function (event) {
+  const requestInterceptedAt = Date.now()
+
+  // Bypass navigation requests.
+  if (event.request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (
+    event.request.cache === 'only-if-cached' &&
+    event.request.mode !== 'same-origin'
+  ) {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been terminated (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = crypto.randomUUID()
+  event.respondWith(handleRequest(event, requestId, requestInterceptedAt))
+})
+
+/**
+ * @param {FetchEvent} event
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ */
+async function handleRequest(event, requestId, requestInterceptedAt) {
+  const client = await resolveMainClient(event)
+  const requestCloneForEvents = event.request.clone()
+  const response = await getResponse(
+    event,
+    client,
+    requestId,
+    requestInterceptedAt,
+  )
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    const serializedRequest = await serializeRequest(requestCloneForEvents)
+
+    // Clone the response so both the client and the library could consume it.
+    const responseClone = response.clone()
+
+    sendToClient(
+      client,
+      {
+        type: 'RESPONSE',
+        payload: {
+          isMockedResponse: IS_MOCKED_RESPONSE in response,
+          request: {
+            id: requestId,
+            ...serializedRequest,
+          },
+          response: {
+            type: responseClone.type,
+            status: responseClone.status,
+            statusText: responseClone.statusText,
+            headers: Object.fromEntries(responseClone.headers.entries()),
+            body: responseClone.body,
+          },
+        },
+      },
+      responseClone.body ? [serializedRequest.body, responseClone.body] : [],
+    )
+  }
+
+  return response
+}
+
+/**
+ * Resolve the main client for the given event.
+ * Client that issues a request doesn't necessarily equal the client
+ * that registered the worker. It's with the latter the worker should
+ * communicate with during the response resolving phase.
+ * @param {FetchEvent} event
+ * @returns {Promise<Client | undefined>}
+ */
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (activeClientIds.has(event.clientId)) {
+    return client
+  }
+
+  if (client?.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: 'window',
+  })
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+/**
+ * @param {FetchEvent} event
+ * @param {Client | undefined} client
+ * @param {string} requestId
+ * @param {number} requestInterceptedAt
+ * @returns {Promise<Response>}
+ */
+async function getResponse(event, client, requestId, requestInterceptedAt) {
+  // Clone the request because it might've been already used
+  // (i.e. its body has been read and sent to the client).
+  const requestClone = event.request.clone()
+
+  function passthrough() {
+    // Cast the request headers to a new Headers instance
+    // so the headers can be manipulated with.
+    const headers = new Headers(requestClone.headers)
+
+    // Remove the "accept" header value that marked this request as passthrough.
+    // This prevents request alteration and also keeps it compliant with the
+    // user-defined CORS policies.
+    const acceptHeader = headers.get('accept')
+    if (acceptHeader) {
+      const values = acceptHeader.split(',').map((value) => value.trim())
+      const filteredValues = values.filter(
+        (value) => value !== 'msw/passthrough',
+      )
+
+      if (filteredValues.length > 0) {
+        headers.set('accept', filteredValues.join(', '))
+      } else {
+        headers.delete('accept')
+      }
+    }
+
+    return fetch(requestClone, { headers })
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough()
+  }
+
+  // Notify the client that a request has been intercepted.
+  const serializedRequest = await serializeRequest(event.request)
+  const clientMessage = await sendToClient(
+    client,
+    {
+      type: 'REQUEST',
+      payload: {
+        id: requestId,
+        interceptedAt: requestInterceptedAt,
+        ...serializedRequest,
+      },
+    },
+    [serializedRequest.body],
+  )
+
+  switch (clientMessage.type) {
+    case 'MOCK_RESPONSE': {
+      return respondWithMock(clientMessage.data)
+    }
+
+    case 'PASSTHROUGH': {
+      return passthrough()
+    }
+  }
+
+  return passthrough()
+}
+
+/**
+ * @param {Client} client
+ * @param {any} message
+ * @param {Array<Transferable>} transferrables
+ * @returns {Promise<any>}
+ */
+function sendToClient(client, message, transferrables = []) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(message, [
+      channel.port2,
+      ...transferrables.filter(Boolean),
+    ])
+  })
+}
+
+/**
+ * @param {Response} response
+ * @returns {Response}
+ */
+function respondWithMock(response) {
+  // Setting response status code to 0 is a no-op.
+  // However, when responding with a "Response.error()", the produced Response
+  // instance will have status code set to 0. Since it's not possible to create
+  // a Response instance with status code 0, handle that use-case separately.
+  if (response.status === 0) {
+    return Response.error()
+  }
+
+  const mockedResponse = new Response(response.body, response)
+
+  Reflect.defineProperty(mockedResponse, IS_MOCKED_RESPONSE, {
+    value: true,
+    enumerable: true,
+  })
+
+  return mockedResponse
+}
+
+/**
+ * @param {Request} request
+ */
+async function serializeRequest(request) {
+  return {
+    url: request.url,
+    mode: request.mode,
+    method: request.method,
+    headers: Object.fromEntries(request.headers.entries()),
+    cache: request.cache,
+    credentials: request.credentials,
+    destination: request.destination,
+    integrity: request.integrity,
+    redirect: request.redirect,
+    referrer: request.referrer,
+    referrerPolicy: request.referrerPolicy,
+    body: await request.arrayBuffer(),
+    keepalive: request.keepalive,
+  }
+}

--- a/src/app/(main)/books/[bookId]/page.tsx
+++ b/src/app/(main)/books/[bookId]/page.tsx
@@ -114,6 +114,11 @@ export default function BookPage() {
               <strong>Страниц:</strong> {book.pages}
             </div>
           </div>
+          {book.isFavorite && (
+            <div style={{ color: 'red', fontSize: '18px', marginTop: '5px' }}>
+              ❤️
+            </div>
+          )}
 
           {/* Блок владельца */}
           {/* Здесь будет информация о пользователе, но для него нужно создавать отдельные моковые данные + прописывать интерфейс, так что оставляем пустым */}

--- a/src/app/(main)/books/[bookId]/page.tsx
+++ b/src/app/(main)/books/[bookId]/page.tsx
@@ -1,8 +1,124 @@
-export default async function Page({
-  params,
-}: {
-  params: Promise<{ bookId: unknown }>
-}) {
-  console.log(params)
-  return <div>Welcome book</div>
+'use client'
+
+import { useEffect } from 'react'
+import { useParams } from 'next/navigation'
+import Image from 'next/image'
+import {
+  fetchBookById,
+  clearDetails,
+  selectBookDetailsData,
+  selectBookDetailsIsLoading,
+} from '@entities/book/model'
+import { useAppDispatch, useAppSelector } from '@shared/hooks'
+
+export default function BookPage() {
+  const params = useParams()
+  const id = params.bookId as string
+  const dispatch = useAppDispatch()
+  const book = useAppSelector(selectBookDetailsData)
+  const isLoading = useAppSelector(selectBookDetailsIsLoading)
+
+  useEffect(() => {
+    if (id) {
+      dispatch(fetchBookById(id as string))
+    }
+
+    return () => {
+      dispatch(clearDetails())
+    }
+  }, [dispatch, id])
+
+  if (isLoading) return <div>Загрузка полной информации...</div>
+  if (!book) return <div>Книга не найдена</div>
+
+  return (
+    <main style={{ padding: '20px', maxWidth: '1200px', margin: '0 auto' }}>
+      {/* Сетка: Слева фото, справа инфо */}
+      <div
+        style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: '40px' }}
+      >
+        {/* Блок изображений */}
+        <section>
+          <div
+            style={{
+              position: 'relative',
+              width: '100%',
+              height: '500px',
+              backgroundColor: '#f5f5f5',
+            }}
+          >
+            <Image
+              src={book.thumbnails[0]}
+              alt={book.title}
+              fill
+              style={{ objectFit: 'contain' }}
+              priority
+            />
+          </div>
+          {/* Миниатюры */}
+          <div style={{ display: 'flex', gap: '10px', marginTop: '10px' }}>
+            {book.thumbnails.slice(1).map((url, idx) => (
+              <div
+                key={idx}
+                style={{ position: 'relative', width: '80px', height: '100px' }}
+              >
+                <Image src={url} alt='' fill style={{ objectFit: 'cover' }} />
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Блок заголовка */}
+        <section>
+          <h1 style={{ fontSize: '2rem', marginBottom: '10px' }}>
+            {book.title}
+          </h1>
+          <h2
+            style={{ fontSize: '1.2rem', color: '#555', marginBottom: '20px' }}
+          >
+            {book.author}
+          </h2>
+
+          {/* Таблица описания */}
+          <div style={{ marginBottom: '30px' }}>
+            <h3>Описание</h3>
+            <p style={{ lineHeight: '1.6' }}>{book.description}</p>
+          </div>
+          <div
+            style={{
+              display: 'grid',
+              gridTemplateColumns: '1fr 1fr',
+              gap: '10px',
+              fontSize: '14px',
+            }}
+          >
+            <div>
+              <strong>Издательство:</strong> {book.publisher}
+            </div>
+            <div>
+              <strong>Год издания:</strong> {book.year}
+            </div>
+            <div>
+              <strong>Жанр:</strong> {book.genre}
+            </div>
+            <div>
+              <strong>Категория:</strong> {book.condition}
+            </div>
+            <div>
+              <strong>Язык:</strong> {book.language}
+            </div>
+            <div>
+              <strong>Переплет:</strong> {book.binding}
+            </div>
+            <div>
+              <strong>Страниц:</strong> {book.pages}
+            </div>
+          </div>
+
+          {/* Блок владельца */}
+          {/* Здесь будет информация о пользователе, но для него нужно создавать отдельные моковые данные + прописывать интерфейс, так что оставляем пустым */}
+        </section>
+      </div>
+    </main>
+  )
 }

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -1,6 +1,12 @@
 import { useTranslations } from 'next-intl'
+import { BooksFeed } from '@/widgets/bookList'
 
 export default function Page() {
   const t = useTranslations('HomePage')
-  return <div>{t('title')}</div>
+  return (
+    <>
+      <div>{t('title')}</div>
+      <BooksFeed />
+    </>
+  )
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,8 +1,8 @@
 import 'normalize.css/normalize.css'
 import '@styles/global.scss'
 import ReduxProvider from '@providers/redux/redux.provider'
-import { LayoutProps } from '@shared/lib/types'
 import { I18nProvider } from '@providers/i18n/i18n.provider'
+import { LayoutProps } from '@shared/lib/types'
 
 export default async function RootLayout({ children }: Readonly<LayoutProps>) {
   return (

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,15 +2,18 @@ import 'normalize.css/normalize.css'
 import '@styles/global.scss'
 import ReduxProvider from '@providers/redux/redux.provider'
 import { I18nProvider } from '@providers/i18n/i18n.provider'
+import { MSWProvider } from './providers/msw/msw.provider'
 import { LayoutProps } from '@shared/lib/types'
 
 export default async function RootLayout({ children }: Readonly<LayoutProps>) {
   return (
     <html>
       <body>
-        <I18nProvider>
-          <ReduxProvider>{children}</ReduxProvider>
-        </I18nProvider>
+        <MSWProvider>
+          <I18nProvider>
+            <ReduxProvider>{children}</ReduxProvider>
+          </I18nProvider>
+        </MSWProvider>
       </body>
     </html>
   )

--- a/src/app/providers/msw/msw.provider.tsx
+++ b/src/app/providers/msw/msw.provider.tsx
@@ -1,0 +1,16 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { enableMocking } from '@mocks/enableMocking'
+
+export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
+  const [isReady, setIsReady] = useState(false)
+
+  useEffect(() => {
+    enableMocking().then(() => setIsReady(true))
+  }, [])
+
+  if (!isReady && process.env.NODE_ENV === 'development') return null
+
+  return <>{children}</>
+}

--- a/src/app/providers/msw/msw.provider.tsx
+++ b/src/app/providers/msw/msw.provider.tsx
@@ -10,7 +10,7 @@ export const MSWProvider = ({ children }: { children: React.ReactNode }) => {
     enableMocking().then(() => setIsReady(true))
   }, [])
 
-  if (!isReady && process.env.NODE_ENV === 'development') return null
+  if (!isReady) return null
 
   return <>{children}</>
 }

--- a/src/app/providers/redux/store.ts
+++ b/src/app/providers/redux/store.ts
@@ -1,7 +1,11 @@
 import { configureStore } from '@reduxjs/toolkit'
+import { bookReducer } from '@entities/book/model'
 
 export const store = configureStore({
   reducer: {
-    _stub: (state = {}) => state,
+    book: bookReducer,
   },
 })
+
+export type RootState = ReturnType<typeof store.getState>
+export type AppDispatch = typeof store.dispatch

--- a/src/entities/book/model/index.ts
+++ b/src/entities/book/model/index.ts
@@ -1,2 +1,27 @@
-export type { BookPreview, BookSchema, ExchangeType } from './types'
-export { bookReducer, fetchBookPreviews } from './slice'
+export type {
+  ExchangeType,
+  BookCondition,
+  BindingType,
+  Category,
+  FilterType,
+  User,
+  CatalogFilters,
+  BookPreview,
+  Book,
+  BookSchema,
+} from './types'
+export {
+  bookReducer,
+  fetchBooksCatalog,
+  fetchBookById,
+  clearDetails,
+} from './slice'
+export {
+  selectBookCatalogItems,
+  selectBookCatalogIsLoading,
+  selectBookCatalogError,
+  selectBookCatalogFilters,
+  selectBookDetailsData,
+  selectBookDetailsIsLoading,
+  selectBookDetailsError,
+} from './selectors'

--- a/src/entities/book/model/index.ts
+++ b/src/entities/book/model/index.ts
@@ -1,0 +1,2 @@
+export type { BookPreview, BookSchema, ExchangeType } from './types'
+export { bookReducer, fetchBookPreviews } from './slice'

--- a/src/entities/book/model/selectors.ts
+++ b/src/entities/book/model/selectors.ts
@@ -1,0 +1,23 @@
+import type { BookSchema } from './types'
+
+interface PartialState {
+  book: BookSchema
+}
+
+// Селекторы для каталога
+export const selectBookCatalogItems = (state: PartialState) =>
+  state.book.catalog.entities
+export const selectBookCatalogIsLoading = (state: PartialState) =>
+  state.book.catalog.isLoading
+export const selectBookCatalogError = (state: PartialState) =>
+  state.book.catalog.error
+export const selectBookCatalogFilters = (state: PartialState) =>
+  state.book.catalog.filters
+
+// Селекторы для детальной страницы
+export const selectBookDetailsData = (state: PartialState) =>
+  state.book.details.data
+export const selectBookDetailsIsLoading = (state: PartialState) =>
+  state.book.details.isLoading
+export const selectBookDetailsError = (state: PartialState) =>
+  state.book.details.error

--- a/src/entities/book/model/slice.ts
+++ b/src/entities/book/model/slice.ts
@@ -1,0 +1,40 @@
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+import { BookPreview, BookSchema } from './types'
+
+export const fetchBookPreviews = createAsyncThunk(
+  'book/fetchBooks',
+  async () => {
+    const response = await fetch('/api/books/preview')
+    if (!response.ok) throw new Error('Failed to fetch')
+    return (await response.json()) as BookPreview[]
+  },
+)
+
+const initialState: BookSchema = {
+  data: [],
+  isLoading: false,
+  error: null,
+}
+
+export const bookSlice = createSlice({
+  name: 'book',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      .addCase(fetchBookPreviews.pending, state => {
+        state.isLoading = true
+        state.error = null
+      })
+      .addCase(fetchBookPreviews.fulfilled, (state, action) => {
+        state.isLoading = false
+        state.data = action.payload
+      })
+      .addCase(fetchBookPreviews.rejected, (state, action) => {
+        state.isLoading = false
+        state.error = action.error.message || 'Error'
+      })
+  },
+})
+
+export const { reducer: bookReducer } = bookSlice

--- a/src/entities/book/model/slice.ts
+++ b/src/entities/book/model/slice.ts
@@ -1,40 +1,84 @@
-import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
-import { BookPreview, BookSchema } from './types'
+import { createSlice, createAsyncThunk, PayloadAction } from '@reduxjs/toolkit'
+import type { Category, BookPreview, Book, BookSchema } from './types'
 
-export const fetchBookPreviews = createAsyncThunk(
-  'book/fetchBooks',
+export const fetchBooksCatalog = createAsyncThunk(
+  'book/fetchCatalog',
   async () => {
     const response = await fetch('/api/books/preview')
-    if (!response.ok) throw new Error('Failed to fetch')
+    if (!response.ok) throw new Error('Failed to fetch catalog')
     return (await response.json()) as BookPreview[]
   },
 )
 
-const initialState: BookSchema = {
-  data: [],
-  isLoading: false,
-  error: null,
+export const fetchBookById = createAsyncThunk(
+  'book/fetchById',
+  async (id: string) => {
+    const response = await fetch(`/api/books/${id}`)
+    if (!response.ok) throw new Error('Failed to fetch book details')
+    return (await response.json()) as Book
+  },
+)
+
+export const initialState: BookSchema = {
+  catalog: {
+    entities: [],
+    isLoading: false,
+    error: null,
+    filters: {
+      category: 'All',
+      filterType: 'all',
+    },
+  },
+  details: {
+    data: null,
+    isLoading: false,
+    error: null,
+  },
 }
 
 export const bookSlice = createSlice({
   name: 'book',
   initialState,
-  reducers: {},
+  reducers: {
+    setCategory: (state, action: PayloadAction<Category>) => {
+      state.catalog.filters.category = action.payload
+    },
+    clearDetails: state => {
+      state.details.data = null
+      state.details.error = null
+    },
+  },
   extraReducers: builder => {
     builder
-      .addCase(fetchBookPreviews.pending, state => {
-        state.isLoading = true
-        state.error = null
+      // Кейсы для каталога
+      .addCase(fetchBooksCatalog.pending, state => {
+        state.catalog.isLoading = true
+        state.catalog.error = null
       })
-      .addCase(fetchBookPreviews.fulfilled, (state, action) => {
-        state.isLoading = false
-        state.data = action.payload
+      .addCase(fetchBooksCatalog.fulfilled, (state, action) => {
+        state.catalog.isLoading = false
+        state.catalog.entities = action.payload
       })
-      .addCase(fetchBookPreviews.rejected, (state, action) => {
-        state.isLoading = false
-        state.error = action.error.message || 'Error'
+      .addCase(fetchBooksCatalog.rejected, (state, action) => {
+        state.catalog.isLoading = false
+        state.catalog.error = action.error.message || 'Error'
+      })
+
+      // Кейсы для деталей
+      .addCase(fetchBookById.pending, state => {
+        state.details.isLoading = true
+        state.details.error = null
+      })
+      .addCase(fetchBookById.fulfilled, (state, action) => {
+        state.details.isLoading = false
+        state.details.data = action.payload
+      })
+      .addCase(fetchBookById.rejected, (state, action) => {
+        state.details.isLoading = false
+        state.details.error = action.error.message || 'Error'
       })
   },
 })
 
 export const { reducer: bookReducer } = bookSlice
+export const { setCategory, clearDetails } = bookSlice.actions

--- a/src/entities/book/model/types.ts
+++ b/src/entities/book/model/types.ts
@@ -26,6 +26,7 @@ export interface User {
   }
 }
 
+// Сделал ограниченную сортировку, потому она в будущем будет проходить через БД, а не на клиенте
 export interface CatalogFilters {
   category: Category
   filterType: FilterType
@@ -49,6 +50,8 @@ export interface Book {
   author: string
   description: string
   thumbnails: string[]
+  isFavorite?: boolean
+
   publisher: string
   year: number
   binding: BindingType
@@ -56,9 +59,11 @@ export interface Book {
   genre: Category
   language: string
   condition: BookCondition
+
   owner: User
   exchangeType: ExchangeType
   status: 'available' | 'reserved' | 'closed'
+
   createdAt: string
   updatedAt: string
 }

--- a/src/entities/book/model/types.ts
+++ b/src/entities/book/model/types.ts
@@ -1,0 +1,19 @@
+export type ExchangeType = 'free' | 'temporary' | 'exchange'
+
+export interface BookPreview {
+  id: string
+  title: string
+  author: string
+  thumbnail: string | null
+  ownerId: string
+  location: string
+  exchangeType: ExchangeType
+  status: 'available' | 'reserved'
+  createdAt: string
+}
+
+export interface BookSchema {
+  data: BookPreview[]
+  isLoading: boolean
+  error: string | null
+}

--- a/src/entities/book/model/types.ts
+++ b/src/entities/book/model/types.ts
@@ -1,19 +1,80 @@
-export type ExchangeType = 'free' | 'temporary' | 'exchange'
+export type ExchangeType = 'free' | 'exchange'
+export type BookCondition = 'New' | 'Good' | 'Fair' | 'Poor'
+export type BindingType = 'Hardcover' | 'Softcover'
+export type Category =
+  | 'All'
+  | 'ShareBook'
+  | 'Detectives'
+  | 'Romance'
+  | 'Science'
+  | 'Art'
+  | 'Textbooks'
+export type FilterType = ExchangeType | 'all'
+
+// Пока не используется, думаю он уйдет в сущность пользователя, но так как пользователя еще не существует, останется тут
+export interface User {
+  id: string
+  name: string
+  avatar: string | null
+  stats: {
+    given: number
+    exchanged: number
+  }
+  location: {
+    city: string
+    district: string
+  }
+}
+
+export interface CatalogFilters {
+  category: Category
+  filterType: FilterType
+}
 
 export interface BookPreview {
   id: string
   title: string
   author: string
-  thumbnail: string | null
-  ownerId: string
-  location: string
+  thumbnail: string
+  location: {
+    city: string
+    district: string
+  }
+  isFavorite?: boolean
+}
+
+export interface Book {
+  id: string
+  title: string
+  author: string
+  description: string
+  thumbnails: string[]
+  publisher: string
+  year: number
+  binding: BindingType
+  pages: number
+  genre: Category
+  language: string
+  condition: BookCondition
+  owner: User
   exchangeType: ExchangeType
-  status: 'available' | 'reserved'
+  status: 'available' | 'reserved' | 'closed'
   createdAt: string
+  updatedAt: string
 }
 
 export interface BookSchema {
-  data: BookPreview[]
-  isLoading: boolean
-  error: string | null
+  // Ветка для превью книг в каталоге
+  catalog: {
+    entities: BookPreview[]
+    isLoading: boolean
+    error: string | null
+    filters: CatalogFilters
+  }
+  // Ветка детальной информации о конкретной книге
+  details: {
+    data: Book | null
+    isLoading: boolean
+    error: string | null
+  }
 }

--- a/src/features/language-switcher/ui/LangSwitcher.tsx
+++ b/src/features/language-switcher/ui/LangSwitcher.tsx
@@ -3,8 +3,8 @@
 import { useTransition } from 'react'
 import { useRouter } from 'next/navigation'
 import { useLocale } from 'next-intl'
-import { Locale, locales } from '@shared/config'
 import { changeLanguageAction } from '../api/change-language'
+import { Locale, locales } from '@shared/config'
 
 export const LangSwitcher = () => {
   const [isPending, startTransition] = useTransition()

--- a/src/mocks/browser.ts
+++ b/src/mocks/browser.ts
@@ -1,0 +1,4 @@
+import { setupWorker } from 'msw/browser'
+import { handlers } from '@mocks/handlers'
+
+export const worker = setupWorker(...handlers)

--- a/src/mocks/enableMocking.ts
+++ b/src/mocks/enableMocking.ts
@@ -1,0 +1,20 @@
+export async function enableMocking() {
+  console.log('Check env', {
+    ENV: process.env.NODE_ENV,
+    MSW: process.env.NEXT_PUBLIC_MSW,
+  })
+  if (process.env.NODE_ENV !== 'development') return
+  if (process.env.NEXT_PUBLIC_MSW !== 'true') return
+
+  if (typeof window === 'undefined') {
+    // NODE.JS (Server Side)
+    const { server } = await import('./server')
+    server.listen({ onUnhandledRequest: 'bypass' })
+  } else {
+    // BROWSER (Client Side)
+    const { worker } = await import('./browser')
+    console.log('MSW: Trying to start worker...')
+    await worker.start({ onUnhandledRequest: 'bypass' })
+    console.log('MSW: Worker started successfully!')
+  }
+}

--- a/src/mocks/entities/books.ts
+++ b/src/mocks/entities/books.ts
@@ -72,6 +72,7 @@ const generateMockBooks = (count: number): Book[] => {
       genre: categories[i % categories.length],
       language: 'Русский',
       condition: 'Good' as BookCondition,
+      isFavorite: Math.random() > 0.8,
       owner: {
         id: `user-${i}`,
         name: i % 2 === 0 ? 'Евгения' : 'Александр',
@@ -99,7 +100,7 @@ export const bookHandlers = [
       author: book.author,
       thumbnail: book.thumbnails[0],
       location: book.owner.location,
-      isFavorite: Math.random() > 0.8,
+      isFavorite: book.isFavorite,
     }))
 
     return HttpResponse.json(previews)

--- a/src/mocks/entities/books.ts
+++ b/src/mocks/entities/books.ts
@@ -1,48 +1,127 @@
 import { http, HttpResponse, delay } from 'msw'
-import { BookPreview, ExchangeType } from '@entities/book/model'
+import {
+  Book,
+  BookPreview,
+  Category,
+  BindingType,
+  BookCondition,
+} from '@entities/book/model'
 
-const exchangeTypes: ExchangeType[] = ['free', 'temporary', 'exchange']
+const categories: Category[] = [
+  'Science',
+  'Detectives',
+  'Romance',
+  'Art',
+  'Textbooks',
+]
 const locations = [
-  'Москва, ЦАО',
-  'Санкт-Петербург, Выборгский р-н',
-  'Казань',
-  'Новосибирск',
-  'Екатеринбург',
+  { city: 'Санкт-Петербург', district: 'Выборгский р-н' },
+  { city: 'Москва', district: 'ЦАО' },
+  { city: 'Санкт-Петербург', district: 'Приморский р-н' },
 ]
 
-// Функция-генератор для создания массива из 20 книг
-const generateMockBooks = (count: number): BookPreview[] => {
-  return Array.from({ length: count }, (_, i) => ({
-    id: `book-id-${i + 1}`,
-    title:
-      i % 5 === 0
-        ? `Очень длинное название книги для проверки переполнения текста номер ${i + 1}`
-        : `Книга про разработку #${i + 1}`,
-    author: i % 3 === 0 ? 'Роберт Мартин' : 'Линус Торвальдс',
-    thumbnail:
-      i % i === 0 ? null : `https://picsum.photos/seed/${i + 1}/200/300`,
-    ownerId: `user-${i}`,
-    location: locations[i % locations.length],
-    exchangeType: exchangeTypes[i % exchangeTypes.length],
-    status: i % 7 === 0 ? 'reserved' : 'available',
-    createdAt: new Date().toISOString(),
-  }))
+// Это способ создать валидный data URL для SVG, который будет работать c turbopack, при этом не ломая SVGR с импортами SVG как React-компонента. Для моков другие варианты избыточны
+const getPlaceholderSvg = (color: string) => {
+  const svg = `<svg width="400" height="600" viewBox="0 0 400 600" xmlns="http://www.w3.org/2000/svg"><rect width="400" height="600" fill="${color}"/><text x="50%" y="50%" text-anchor="middle" fill="#000000" font-family="Impact" font-size="32">Обложка книги</text></svg>`
+
+  const encodedSvg = svg
+    .replace(/%/g, '%25')
+    .replace(/#/g, '%23')
+    .replace(/{/g, '%7B')
+    .replace(/}/g, '%7D')
+    .replace(/</g, '%3C')
+    .replace(/>/g, '%3E')
+
+  return `data:image/svg+xml;utf8,${encodedSvg}`
+}
+
+const MOCK_COLORS = [
+  '#FFD700', // Gold
+  '#FF6B6B', // Red
+  '#4ECDC4', // Teal
+  '#45B7D1', // Blue
+  '#96CEB4', // Green
+  '#FFEEAD', // Cream
+  '#D4A5A5', // Pink
+  '#9B59B6', // Purple
+]
+
+const generateMockBooks = (count: number): Book[] => {
+  return Array.from({ length: count }, (_, i) => {
+    const bookId = i + 1
+
+    const bookColors = MOCK_COLORS.map((_, idx) => {
+      const colorIndex = (idx + bookId * 3) % MOCK_COLORS.length
+      return MOCK_COLORS[colorIndex]
+    })
+
+    return {
+      id: String(bookId),
+      title:
+        i % 5 === 0
+          ? `Длинное название книги для теста верстки #${i + 1}`
+          : `Книга #${i + 1}`,
+      author: i % 2 === 0 ? 'Стивен Хокинг' : 'Марио Варгас Льоса',
+      description:
+        'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam eu turpis molestie, dictum est a, mattis tellus.',
+      thumbnails: bookColors.map(color => getPlaceholderSvg(color)),
+      publisher: 'Издательство АСТ',
+      year: 2022,
+      binding: 'Hardcover' as BindingType,
+      pages: 200 + i,
+      genre: categories[i % categories.length],
+      language: 'Русский',
+      condition: 'Good' as BookCondition,
+      owner: {
+        id: `user-${i}`,
+        name: i % 2 === 0 ? 'Евгения' : 'Александр',
+        avatar: `https://i.pravatar.cc/150?u=${i}`,
+        stats: { given: 10, exchanged: 5 },
+        location: locations[i % locations.length],
+      },
+      exchangeType: i % 2 === 0 ? 'free' : 'exchange',
+      status: 'available',
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    }
+  })
 }
 
 const mockBooks = generateMockBooks(20)
 
 export const bookHandlers = [
   http.get('/api/books/preview', async () => {
-    await delay(1000)
-    return HttpResponse.json(mockBooks)
+    await delay(800)
+
+    const previews: BookPreview[] = mockBooks.map(book => ({
+      id: book.id,
+      title: book.title,
+      author: book.author,
+      thumbnail: book.thumbnails[0],
+      location: book.owner.location,
+      isFavorite: Math.random() > 0.8,
+    }))
+
+    return HttpResponse.json(previews)
   }),
 
   http.get('/api/books/:id', async ({ params }) => {
+    await delay(500)
     const { id } = params
-    const book = mockBooks.find(b => b.id === id)
+
+    console.log('MSW: Запрос книги с ID:', id)
+    console.log(
+      'MSW: Доступные ID в моках:',
+      mockBooks.map(b => b.id),
+    )
+    const book = mockBooks.find(b => String(b.id) === String(id))
 
     if (!book) {
-      return new HttpResponse(null, { status: 404 })
+      console.error(`MSW: Книга с ID ${id} не найдена!`)
+      return new HttpResponse(null, {
+        status: 404,
+        statusText: 'Book not found',
+      })
     }
 
     return HttpResponse.json(book)

--- a/src/mocks/entities/books.ts
+++ b/src/mocks/entities/books.ts
@@ -1,0 +1,50 @@
+import { http, HttpResponse, delay } from 'msw'
+import { BookPreview, ExchangeType } from '@entities/book/model'
+
+const exchangeTypes: ExchangeType[] = ['free', 'temporary', 'exchange']
+const locations = [
+  'Москва, ЦАО',
+  'Санкт-Петербург, Выборгский р-н',
+  'Казань',
+  'Новосибирск',
+  'Екатеринбург',
+]
+
+// Функция-генератор для создания массива из 20 книг
+const generateMockBooks = (count: number): BookPreview[] => {
+  return Array.from({ length: count }, (_, i) => ({
+    id: `book-id-${i + 1}`,
+    title:
+      i % 5 === 0
+        ? `Очень длинное название книги для проверки переполнения текста номер ${i + 1}`
+        : `Книга про разработку #${i + 1}`,
+    author: i % 3 === 0 ? 'Роберт Мартин' : 'Линус Торвальдс',
+    thumbnail:
+      i % i === 0 ? null : `https://picsum.photos/seed/${i + 1}/200/300`,
+    ownerId: `user-${i}`,
+    location: locations[i % locations.length],
+    exchangeType: exchangeTypes[i % exchangeTypes.length],
+    status: i % 7 === 0 ? 'reserved' : 'available',
+    createdAt: new Date().toISOString(),
+  }))
+}
+
+const mockBooks = generateMockBooks(20)
+
+export const bookHandlers = [
+  http.get('/api/books/preview', async () => {
+    await delay(1000)
+    return HttpResponse.json(mockBooks)
+  }),
+
+  http.get('/api/books/:id', async ({ params }) => {
+    const { id } = params
+    const book = mockBooks.find(b => b.id === id)
+
+    if (!book) {
+      return new HttpResponse(null, { status: 404 })
+    }
+
+    return HttpResponse.json(book)
+  }),
+]

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,0 +1,3 @@
+import { bookHandlers } from '@mocks/entities/books'
+
+export const handlers = [...bookHandlers]

--- a/src/mocks/server.ts
+++ b/src/mocks/server.ts
@@ -1,0 +1,4 @@
+import { setupServer } from 'msw/node'
+import { handlers } from '@mocks/handlers'
+
+export const server = setupServer(...handlers)

--- a/src/shared/hooks/index.ts
+++ b/src/shared/hooks/index.ts
@@ -1,0 +1,1 @@
+export { useAppDispatch, useAppSelector } from './useAppRedux'

--- a/src/shared/hooks/useAppRedux.ts
+++ b/src/shared/hooks/useAppRedux.ts
@@ -1,0 +1,5 @@
+import { TypedUseSelectorHook, useDispatch, useSelector } from 'react-redux'
+import type { RootState, AppDispatch } from '@providers/redux/store'
+
+export const useAppDispatch = () => useDispatch<AppDispatch>()
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/src/widgets/bookList/bookList.tsx
+++ b/src/widgets/bookList/bookList.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useEffect } from 'react'
+import Image from 'next/image'
+import { fetchBookPreviews } from '@entities/book/model'
+import { useAppDispatch, useAppSelector } from '@shared/hooks'
+
+export const BooksFeed = () => {
+  const dispatch = useAppDispatch()
+  const { data, isLoading } = useAppSelector(state => state.book)
+
+  useEffect(() => {
+    dispatch(fetchBookPreviews())
+  }, [dispatch])
+
+  if (isLoading) return <div>Загрузка 20 книг...</div>
+
+  return (
+    <div
+      style={{
+        display: 'grid',
+        gap: '20px',
+        margin: '35px',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
+      }}
+    >
+      {data.map(book => (
+        <div
+          key={book.id}
+          style={{
+            border: '1px solid #ccc',
+            padding: '10px',
+            borderRadius: '4px',
+          }}
+        >
+          <div style={{ fontSize: '12px', color: '#888' }}>ID: {book.id}</div>
+          <div style={{ fontWeight: 'bold' }}>{book.title}</div>
+          <div style={{ fontSize: '13px' }}>👤 {book.author}</div>
+          <div style={{ fontSize: '11px', marginTop: '8px' }}>
+            📍 {book.location} <br />
+            🔄 {book.exchangeType} <br />
+            📊 {book.status}
+          </div>
+          {book.thumbnail && (
+            <Image
+              src={book.thumbnail}
+              alt=''
+              width={200}
+              height={300}
+              style={{
+                marginTop: '10px',
+                objectFit: 'cover',
+              }}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/widgets/bookList/bookList.tsx
+++ b/src/widgets/bookList/bookList.tsx
@@ -2,18 +2,24 @@
 
 import { useEffect } from 'react'
 import Image from 'next/image'
-import { fetchBookPreviews } from '@entities/book/model'
+import Link from 'next/link'
+import {
+  fetchBooksCatalog,
+  selectBookCatalogItems,
+  selectBookCatalogIsLoading,
+} from '@entities/book/model'
 import { useAppDispatch, useAppSelector } from '@shared/hooks'
 
 export const BooksFeed = () => {
   const dispatch = useAppDispatch()
-  const { data, isLoading } = useAppSelector(state => state.book)
+  const books = useAppSelector(selectBookCatalogItems)
+  const isLoading = useAppSelector(selectBookCatalogIsLoading)
 
   useEffect(() => {
-    dispatch(fetchBookPreviews())
+    dispatch(fetchBooksCatalog())
   }, [dispatch])
 
-  if (isLoading) return <div>Загрузка 20 книг...</div>
+  if (isLoading) return <div>Загрузка книг...</div>
 
   return (
     <div
@@ -24,36 +30,61 @@ export const BooksFeed = () => {
         gridTemplateColumns: 'repeat(auto-fill, minmax(250px, 1fr))',
       }}
     >
-      {data.map(book => (
-        <div
+      {books.map(book => (
+        <Link
+          href={`/books/${book.id}`}
           key={book.id}
-          style={{
-            border: '1px solid #ccc',
-            padding: '10px',
-            borderRadius: '4px',
-          }}
+          style={{ textDecoration: 'none', color: 'inherit' }}
         >
-          <div style={{ fontSize: '12px', color: '#888' }}>ID: {book.id}</div>
-          <div style={{ fontWeight: 'bold' }}>{book.title}</div>
-          <div style={{ fontSize: '13px' }}>👤 {book.author}</div>
-          <div style={{ fontSize: '11px', marginTop: '8px' }}>
-            📍 {book.location} <br />
-            🔄 {book.exchangeType} <br />
-            📊 {book.status}
+          <div
+            key={book.id}
+            style={{
+              border: '1px solid #ccc',
+              padding: '10px',
+              borderRadius: '4px',
+              display: 'flex',
+              flexDirection: 'column',
+            }}
+          >
+            <div style={{ fontSize: '12px', color: '#888' }}>ID: {book.id}</div>
+            <div style={{ fontWeight: 'bold' }}>{book.title}</div>
+            <div style={{ fontSize: '13px' }}>👤 {book.author}</div>
+
+            <div style={{ fontSize: '11px', marginTop: '8px', flexGrow: 1 }}>
+              {/* Теперь location — это объект */}
+              📍 {book.location.city}, {book.location.district}
+            </div>
+
+            {book.thumbnail && (
+              <div
+                style={{
+                  position: 'relative',
+                  width: '100%',
+                  height: '300px',
+                  marginTop: '10px',
+                }}
+              >
+                <Image
+                  src={book.thumbnail}
+                  alt={book.title}
+                  fill
+                  sizes='(max-width: 768px) 100vw, 250px'
+                  style={{
+                    objectFit: 'cover',
+                    borderRadius: '2px',
+                  }}
+                />
+              </div>
+            )}
+
+            {/* Простой индикатор избранного */}
+            {book.isFavorite && (
+              <div style={{ color: 'red', fontSize: '18px', marginTop: '5px' }}>
+                ❤️
+              </div>
+            )}
           </div>
-          {book.thumbnail && (
-            <Image
-              src={book.thumbnail}
-              alt=''
-              width={200}
-              height={300}
-              style={{
-                marginTop: '10px',
-                objectFit: 'cover',
-              }}
-            />
-          )}
-        </div>
+        </Link>
       ))}
     </div>
   )

--- a/src/widgets/bookList/index.ts
+++ b/src/widgets/bookList/index.ts
@@ -1,0 +1,1 @@
+export { BooksFeed } from './bookList'

--- a/src/widgets/header-main/ui/header.tsx
+++ b/src/widgets/header-main/ui/header.tsx
@@ -5,10 +5,10 @@ import styles from './header.module.scss'
 import ProfileIcon from '@icons/profile.svg'
 import Logo from '@icons/logo.svg'
 import SearchIcon from '@icons/search.svg'
-import { onest } from '@shared/fonts'
 import clsx from 'clsx'
 import { usePathname } from 'next/navigation'
 import { LangSwitcher } from '@/features/language-switcher'
+import { onest } from '@shared/fonts'
 
 const links = [
   { name: 'Главная', href: '/' },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,8 @@
       "@shared/*": ["src/shared/*"],
       "@widgets/*": ["src/widgets/*"],
       "@features/*": ["src/features/*"],
+      "@entities/*": ["src/entities/*"],
+      "@mocks/*": ["src/mocks/*"],
       "@providers/*": ["src/app/providers/*"],
       "@styles/*": ["src/shared/styles/*"],
       "@icons/*": ["src/shared/icons/*"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,6 +30,7 @@
       "@providers/*": ["src/app/providers/*"],
       "@styles/*": ["src/shared/styles/*"],
       "@icons/*": ["src/shared/icons/*"],
+      "@assets/*": ["src/shared/assets/*"]
     },
   },
   "include": [


### PR DESCRIPTION
### Добавлено:
- MSW и его настройка для взаимодействия с моками.
- Добавлены моковые данные для отрисовки книг (формат моков в будущем изменятся)
- Добавлен новый Reducer, теперь взаимодействие с книгами происходит через Redux 
` useEffect(() => {
    dispatch(fetchBookPreviews())
  }, [dispatch])`
  С предварительными импортами 
  `import { fetchBookPreviews } from '@entities/book/model'`
`import { useAppDispatch, useAppSelector } from '@shared/hooks'`
### Изменено:
- Мелкие фиксы ESlint
- Правила импрортирования фотостоков в next.config.ts (временное, в дальнейшем удалить нужно)
- Новые Aliases в `tsconfig.ts` для entities и mocks